### PR TITLE
copy np array to make tensor writable

### DIFF
--- a/server.py
+++ b/server.py
@@ -109,7 +109,7 @@ class ServeClient:
     
     def add_frames(self, frame_np):
         try:
-            speech_prob = self.vad_model(torch.from_numpy(frame_np), self.RATE).item()
+            speech_prob = self.vad_model(torch.from_numpy(frame_np.copy()), self.RATE).item()
             if speech_prob < self.vad_threshold:
                 return
             


### PR DESCRIPTION
Fix warning 
```
UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at C:\cb\pytorch_1000000000000\work\torch\csrc\utils\tensor_numpy.cpp:205.)
  speech_prob = self.vad_model(torch.from_numpy(frame_np), self.RATE).item()
  ```
https://github.com/collabora/whisper-live/issues/9